### PR TITLE
KillChildrenOnExit: Allow multiple pids

### DIFF
--- a/plugins/git-build.js
+++ b/plugins/git-build.js
@@ -37,7 +37,10 @@ function buildConsumer(config, cimpler, repoPath) {
          timeout: config.timeout || 0,
          maxBuffer: config.maxBuffer || 1024 * 1024 * 2
       },
-      killChildrenOnExit = "trap '[ $(jobs -p) ] && kill $(jobs -p)' EXIT",
+      killChildrenOnExit = `trap '[ -z "$(jobs -p)" ] || kill -SIGTERM $(jobs -p) \
+         && sleep 2 \ 
+         && [ -z "$(jobs -p)" ] || kill -SIGKILL $(jobs -p); \
+         wait $(jobs -p)' EXIT`,
       cdToRepo = 'set -v; set -x; cd ' + quote(repoPath);
 
       for(var key in process.env) {


### PR DESCRIPTION
The expression being expanded now has two items rather than the one it had before.
And [ 12312 123123 ] is a syntax error.


See: https://github.com/iFixit/ifixit/pull/30170